### PR TITLE
env: do not recursively init XiangShan

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -3,8 +3,8 @@
 # This script will setup XiangShan develop environment automatically
 
 # Init submodules
-git submodule update --init --recursive
-# TODO: rocket submodules are not needed
+git submodule update --init --recursive DRAMsim3 NEMU NutShell nexus-am
+git submodule update --init XiangShan && make -C XiangShan init;
 
 # Setup XiangShan environment variables
 source env.sh


### PR DESCRIPTION
XiangShan contains multiple copies of rocket-chip, huancun, and other submodules in its submodule. If we execute `git submodule update --init --recursive` on XiangShan, we will get multiple copies of these modules and even have different versions. But in the mill file, we will only choose one to compile. This behavior will confuse the developers, and they need to exclude these modules when doing a full-text search on the XiangShan folder. But we can get this solved by not recursively init the XiangShan submodule.