### PR TITLE
build: update mill script

### DIFF
--- a/setup-tools.sh
+++ b/setup-tools.sh
@@ -3,7 +3,7 @@
 
 apt update
 apt install proxychains4 shadowsocks-libev vim wget git tmux make gcc clang llvm time curl libreadline6-dev libsdl2-dev gcc-riscv64-linux-gnu openjdk-11-jre zlib1g-dev device-tree-compiler flex autoconf bison sqlite3 libsqlite3-dev zstd libzstd-dev
-sh -c "curl -L https://github.com/com-lihaoyi/mill/releases/download/0.11.12/0.11.12 > /usr/local/bin/mill && chmod +x /usr/local/bin/mill"
+sh -c "curl -L https://github.com/com-lihaoyi/mill/releases/download/0.12.5/0.12.5 > /usr/local/bin/mill && chmod +x /usr/local/bin/mill"
 
 # We need to use Verilator 4.204+, so we install Verilator manually
 source ./install-verilator.sh


### PR DESCRIPTION
The new version of mill script comes from millw.
It can correctly handle various mill versions.