### PR TITLE
feat(docker): Cleanup temp files after RUN to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,14 @@ FROM ${BASE_IMAGE}
 
 RUN cd /bin && ln -sf bash sh
 
-RUN apt update
-RUN apt install sudo -y
-RUN apt clean
-
 COPY install-verilator.sh /tmp/install-verilator.sh
 COPY setup-tools.sh /tmp/setup-tools.sh
-RUN cd /tmp && bash ./setup-tools.sh
+
+WORKDIR /tmp
+RUN apt-get update && apt-get install sudo -y \
+    && bash /tmp/setup-tools.sh \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/verilator
 
 CMD [ "/bin/bash" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY setup-tools.sh /tmp/setup-tools.sh
 WORKDIR /tmp
 RUN apt-get update && apt-get install sudo -y \
     && bash /tmp/setup-tools.sh \
+    && cp /tmp/verilator/ci/docker/run/verilator-wrap.sh /usr/local/bin/ \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/verilator


### PR DESCRIPTION
After cleanup temp files, the image size will be reduced from 2.99GB to 2.39GB