### PR TITLE
fix(nix): fix runtime error of runtime difftest ld

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-
 out/
 .direnv/
+.vscode/

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,8 @@
         echo "- $(riscv64-unknown-linux-gnu-gcc --version | head -n 1)"
         echo "- $(java -version 2>&1 | head -n 1)"
         echo "You can press Ctrl + D to exit devshell."
+        export LD_LIBRARY_PATH="${pkgs.zlib}/lib:${pkgs.stdenv.cc.cc.lib}/lib:$LD_LIBRARY_PATH"
+        source $(pwd)/env.sh
       '';
     };
   };


### PR DESCRIPTION
This PR fix the problem of LD generated when running Xiangshan difftest by adding $LD_LIBRARY_PATH environment variable. 

The reason is that glibc used in `nix shell` lacks libz.so related dependencies

For example, you can execute:
```shell
❯ ldd ./XiangShan/ready-to-run/riscv64-nemu-interpreter-so
        linux-vdso.so.1 (0x00007c39ecb48000)
        libz.so.1 => not found
        libstdc++.so.6 => not found
        libm.so.6 => /nix/store/g3s0z9r7m1lsfxdk8bj88nw8k8q3dmmg-glibc-2.40-66/lib/libm.so.6 (0x00007c399cf17000)
        libgcc_s.so.1 => /nix/store/fdsndp18qa1fk375vcd4vrn00c0p4zpr-xgcc-14.2.1.20250322-libgcc/lib/libgcc_s.so.1 (0x00007c39ecb14000)
        libc.so.6 => /nix/store/g3s0z9r7m1lsfxdk8bj88nw8k8q3dmmg-glibc-2.40-66/lib/libc.so.6 (0x00007c399cc00000)
        /nix/store/g3s0z9r7m1lsfxdk8bj88nw8k8q3dmmg-glibc-2.40-66/lib64/ld-linux-x86-64.so.2 (0x00007c39ecb4a000)
```

At the same time, this PR also made some simple changes to the nix script

