### PR TITLE
feat: bump verilator to 5.048 & use jemalloc

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,17 +47,21 @@
           };
         }))
         (verilator.overrideAttrs (finalAttrs: previousAttrs: {
-          version = "5.044";
+          version = "5.048";
           VERILATOR_SRC_VERSION = "v${finalAttrs.version}";
           src = fetchFromGitHub {
             owner = "verilator";
             repo = "verilator";
             rev = "v${finalAttrs.version}";
-            hash = "sha256-z3jYNzhnZ+OocDAbmsRBWHNNPXLLvExKK1TLDi9JzPQ=";
+            hash = "sha256-xvqqgbW7L07+NBYzGN2KLhwir58ByShxo4VVPI3pgZk=";
           };
           # drop patch https://github.com/NixOS/nixpkgs/commit/06be23d66287c004cb8ef933a9ff6589276ab104
           # since it's already included in 5.044
           patches = [];
+          # use jemalloc by default
+          buildInputs = previousAttrs.buildInputs ++ [
+            jemalloc
+          ];
           doCheck = false;
         }))
         gsim.packages.${system}.default

--- a/install-verilator.sh
+++ b/install-verilator.sh
@@ -2,8 +2,8 @@
 
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get install -y git help2man perl python3 make autoconf g++ flex bison
-apt-get install -y libgoogle-perftools-dev numactl perl-doc
+apt-get install -y git help2man perl python3 make autoconf g++ flex bison ccache
+apt-get install -y libgoogle-perftools-dev libjemalloc-dev numactl perl-doc
 apt-get install -y libfl2  # Ubuntu only (ignore if gives error)
 apt-get install -y libfl-dev  # Ubuntu only (ignore if gives error)
 apt-get install -y zlibc zlib1g zlib1g-dev  # Ubuntu only (ignore if gives error)
@@ -20,7 +20,7 @@ git clone https://github.com/verilator/verilator
 unset VERILATOR_ROOT  # For bash
 cd verilator
 
-git checkout v5.044
+git checkout v5.048
 
 autoconf        # Create ./configure script
 # Configure and create Makefile


### PR DESCRIPTION
This gives ~2x verilating speed. Refer to https://github.com/verilator/verilator/pull/7250.

Tested compiling MinimalConfig XiangShan with Intel Core Ultra 265k:
<img width="2658" height="890" alt="b195a15c76e94537208b01f64d110204" src="https://github.com/user-attachments/assets/22beae0f-0868-4236-9270-7f5de367f696" />