### PR TITLE
fix: refine packages

### DIFF
--- a/install-verilator.sh
+++ b/install-verilator.sh
@@ -1,8 +1,12 @@
 # https://verilator.org/guide/latest/install.html
 
+# NOTE: ccache is intentionally removed from the dependencies list, since:
+#   1. it does not help XiangShan's build performance in most cases, as slight change in chisel result in significant change in cpp code
+#   2. it introduces too much IO overhead
+
 export DEBIAN_FRONTEND=noninteractive
 
-apt-get install -y git help2man perl python3 make autoconf g++ flex bison ccache
+apt-get install -y git help2man perl python3 make autoconf g++ flex bison
 apt-get install -y libgoogle-perftools-dev libjemalloc-dev numactl perl-doc
 apt-get install -y libfl2  # Ubuntu only (ignore if gives error)
 apt-get install -y libfl-dev  # Ubuntu only (ignore if gives error)

--- a/setup-tools.sh
+++ b/setup-tools.sh
@@ -6,17 +6,16 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt update
 apt install -y \
-    proxychains4 \
     vim \
     wget \
     git \
-    tmux \
     make \
     g++ \
     time \
     curl \
     libreadline6-dev \
     libsdl2-dev \
+    libgmp-dev \
     g++-riscv64-linux-gnu \
     zlib1g-dev \
     device-tree-compiler \
@@ -30,7 +29,15 @@ apt install -y \
     python-is-python3 \
     python3-protobuf \
     python3-grpc-tools \
-    rsync
+    numactl
+
+# NOTE: uncomment the following lines to install optional tools that we use in our cluster
+# apt install -y \
+#     proxychains4 \
+#     htop \
+#     zsh \
+#     tmux \
+#     rsync
 
 # GSIM requires clang 19+
 if apt list "clang*" | grep clang-19; then


### PR DESCRIPTION
- Comment out proxychains4, tmux, rsync, htop and zsh. Since we also use this script to create docker image, in which these tool are not used.
- Add libgmp-dev for gsim
- Add numactl for xiangshan.py
- Remove ccache, see comments in install-verilator.sh