### PR TITLE
ci: fix empty docker tag

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -3,6 +3,8 @@ name: Build docker image
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build-ubuntu:
@@ -30,7 +32,7 @@ jobs:
           images: |
             ghcr.io/${{ github.repository_owner }}/xs-env
           tags: |
-            ${{ matrix.version == '24.04' && 'latest' || '' }}${{ matrix.full && '-full' || '' }}
+            ${{ matrix.version == '24.04' && 'latest' || '' }}${{ matrix.version == '24.04' && matrix.full && '-full' || '' }}
             ubuntu-${{ matrix.version }}${{ matrix.full && '-full' || '' }}
             ubuntu-${{ matrix.version }}-${{ env.DATE }}${{ matrix.full && '-full' || '' }}
           labels: |
@@ -48,7 +50,7 @@ jobs:
         with:
           context: .
           platforms: linux/amd64
-          push: true
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           build-args: |


### PR DESCRIPTION
fix #76 

if version != 24.04, tag will be `-full`, which is invalid

also enable build test for pull_request