### PR TITLE
feat(nix): use clang to compile verilator

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,8 @@
             hash = "sha256-6hu6AeIg9M4guzMyR9JUor+bhlVMEMPX1+FmQewKdtg=";
           };
         }))
-        (verilator.overrideAttrs (finalAttrs: previousAttrs: {
+        # compile verilator with clang instead of gcc
+        ((verilator.override { stdenv = clangStdenv; }).overrideAttrs (finalAttrs: previousAttrs: {
           version = "5.048";
           VERILATOR_SRC_VERSION = "v${finalAttrs.version}";
           src = fetchFromGitHub {


### PR DESCRIPTION
To align with `install-verilator.sh` and our cluster.

XiangShan MinimalConfig compile(verilator+cxx) time 13min -> 10min @ 265K