### PR TITLE
chore(dependabot): check nix updates more frequently

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,7 @@ updates:
   - package-ecosystem: "nix"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "feat(nix)"
     groups:


### PR DESCRIPTION
Mainly for gsim, but dependabot does not allow multiple entries with the same package-exosystem and different schedule.