### PR TITLE
feat: add python3-psutil and use graalvm-jdk by default

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: build-docker-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build-ubuntu:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,12 +25,17 @@ jobs:
 
       - name: Setup XiangShan environment
         run: |
-            git config --global url."https://github.com/".insteadOf git@github.com:
-            git config --global url."https://".insteadOf git://
-            sudo -s ./setup-tools.sh
-            source ./setup.sh
-      
+          git config --global url."https://github.com/".insteadOf git@github.com:
+          git config --global url."https://".insteadOf git://
+          sudo -s ./setup-tools.sh
+          source ./setup.sh
+          if [ -d /opt/graalvm-jdk-21 ]; then
+            echo "Overriding CI java environment to use GraalVM JDK 21"
+            echo "PATH=/opt/graalvm-jdk-21/bin:${PATH}" >> $GITHUB_ENV
+            echo "JAVA_HOME=/opt/graalvm-jdk-21" >> $GITHUB_ENV
+          fi
+
       - name: Sim NutShell using Verilator
         run: |
-            cd $GITHUB_WORKSPACE
-            source ./env-test.sh
+          cd $GITHUB_WORKSPACE
+          source ./env-test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,7 @@ RUN apt-get update && apt-get install sudo -y \
     && rm -rf /var/lib/apt/lists/* \
     && rm -rf /tmp/verilator
 
+ENV PATH="/opt/graalvm-jdk-21/bin:${PATH}"
+ENV JAVA_HOME="/opt/graalvm-jdk-21"
+
 CMD [ "/bin/bash" ]

--- a/README.md
+++ b/README.md
@@ -7,13 +7,30 @@ XiangShan Frontend Develop Environment
 
 使用以下脚本来布署香山开发环境，**部署脚本只需运行一次.**：
 
-This script will setup XiangShan develop environment automatically. Note that `./setup-tools.sh` and `setup.sh` only need to be run **ONCE**. 
+This script will setup XiangShan develop environment automatically. Note that `./setup-tools.sh` and `setup.sh` only need to be run **ONCE**.
 
 ```sh
 git clone https://github.com/OpenXiangShan/xs-env
 cd xs-env
 sudo -s ./setup-tools.sh # use apt to install dependencies, you may modify it to use different pkg manager
 source setup.sh # prepare tools, test develop env using a small project
+```
+
+该脚本会默认使用 GraalVM JDK 21，请在运行上述脚本后将环境变量配置到 profile（例如 `~/.bashrc`）中：
+
+This script will use GraalVM JDK 21 by default. Please add the following lines to your profile (e.g., `~/.bashrc`) after running the above script:
+
+```sh
+echo 'export PATH="/opt/graalvm-jdk-21/bin:${PATH}"' >> ~/.bashrc
+echo 'export JAVA_HOME="/opt/graalvm-jdk-21"' >> ~/.bashrc
+```
+
+如需使用 OpenJDK 21，可以在运行 setup-tools.sh 前设置环境变量 `WITH_GRALLVMJDK=false` 来禁用 GraalVM JDK 的安装：
+
+If you want to use OpenJDK 21, you can disable GraalVM JDK installation by setting the environment variable `WITH_GRALLVMJDK=false` before running setup-tools.sh:
+
+```sh
+sudo -s WITH_GRALLVMJDK=false ./setup-tools.sh
 ```
 
 由于香山 `master` 分支更新频繁，此仓库中的 submodule 默认追踪香山主线分支上的一个稳定提交，**并不是香山及其他工具的最新版本**。要更新各子仓库到最新版本，可以运行:
@@ -33,11 +50,10 @@ cd xs-env
 source ./env.sh # setup XiangShan environment variables
 ```
 
-
 # Document
 
 详细使用方式请参考完整文档:
 
 For further instructions, see:
 
-[XiangShan Frontend Develop Environment Document](https://xiangshan-doc.readthedocs.io/zh_CN/latest/tools/xsenv/)
+[XiangShan Frontend Develop Environment Document](https://docs.xiangshan.cc/zh-cn/latest/tools/xsenv/)

--- a/env-test.sh
+++ b/env-test.sh
@@ -10,6 +10,12 @@ export NOOP_HOME=$(pwd)/NutShell
 
 cd ${NEMU_HOME}
 
+# Print version info for verification
+echo "$(which gcc): $(gcc --version | head -n 1)"
+echo "$(which clang): $(clang --version | head -n 1)"
+echo "$(which java): $(java --version | head -n 1)"
+echo "$(which verilator): $(verilator --version | head -n 1)"
+
 # CPT_restorer need -march=rv64gcbkvh support. Test here.
 CPT_CROSS_COMPILE_LIST='riscv64-linux-gnu- riscv64-unknown-linux-gnu-'
 for COMPILE in $CPT_CROSS_COMPILE_LIST; do
@@ -31,7 +37,7 @@ cd ${NOOP_HOME}
 make init
 make clean
 # test if mill & Chisel has been installed correctlly
-make verilog 
+make verilog
 # test if verilator has been installed correctlly
 make emu
 # test verilator simulation

--- a/install-verilator.sh
+++ b/install-verilator.sh
@@ -4,13 +4,15 @@
 #   1. it does not help XiangShan's build performance in most cases, as slight change in chisel result in significant change in cpp code
 #   2. it introduces too much IO overhead
 
+set -euo pipefail
+
 export DEBIAN_FRONTEND=noninteractive
 
 apt-get install -y git help2man perl python3 make autoconf g++ flex bison
 apt-get install -y libgoogle-perftools-dev libjemalloc-dev numactl perl-doc
-apt-get install -y libfl2  # Ubuntu only (ignore if gives error)
-apt-get install -y libfl-dev  # Ubuntu only (ignore if gives error)
-apt-get install -y zlibc zlib1g zlib1g-dev  # Ubuntu only (ignore if gives error)
+apt-get install -y libfl2 || true  # Ubuntu only (ignore if gives error)
+apt-get install -y libfl-dev || true  # Ubuntu only (ignore if gives error)
+apt-get install -y zlibc zlib1g zlib1g-dev || true  # Ubuntu only (ignore if gives error)
 
 # we recommend using clang-19 for the moment, but it's not default behavior of ubuntu 24.04
 # so check if clang is installed before actually calling apt install to avoid multiple versions conflict
@@ -29,7 +31,7 @@ git checkout v5.048
 autoconf        # Create ./configure script
 # Configure and create Makefile
 ./configure CC=clang CXX=clang++ LINK=clang++ # We use clang as default compiler
-make -j8        # Build Verilator itself
+make -j$(nproc)        # Build Verilator itself
 make install
 
 verilator --version

--- a/setup-tools.sh
+++ b/setup-tools.sh
@@ -1,5 +1,7 @@
 # This script will setup tools used by XiangShan
-# tested on ubuntu 20.04 Docker image
+# tested on ubuntu 20/22/24.04 Docker image
+
+set -euo pipefail
 
 # make apt non-interactive to avoid tzdata prompt
 export DEBIAN_FRONTEND=noninteractive
@@ -29,9 +31,9 @@ apt install -y \
     python-is-python3 \
     python3-protobuf \
     python3-grpc-tools \
+    python3-psutil \
     numactl
 
-# NOTE: uncomment the following lines to install optional tools that we use in our cluster
 WITH_OPTIONAL_TOOLS=${WITH_OPTIONAL_TOOLS:-false}
 if [ "$WITH_OPTIONAL_TOOLS" = true ]; then
     apt install -y \
@@ -59,8 +61,37 @@ else
     apt install -y llvm-bolt || echo "Skipping llvm-bolt installation, not available in apt repos"
 fi
 
-# openjdk has better performance with newer versions
-apt install -y openjdk-21-jre || apt install -y openjdk-11-jre
+# grallvm has better performace and is enabled by default
+WITH_GRALLVMJDK=${WITH_GRALLVMJDK:-true}
+WITH_OPENJDK=${WITH_OPENJDK:-false}
+JDK_VERSION=21 # do not change this unless tested, XiangShan does not compile with JDK 25 yet
+if [ "${WITH_GRALLVMJDK}" = true ]; then
+    echo "Installing GraalVM JDK ${JDK_VERSION}..."
+
+    case "$(uname -m)" in
+        x86_64) ARCH="linux-x64" ;;
+        aarch64) ARCH="linux-aarch64" ;;
+        *) echo "Unsupported architecture for GraalVM JDK: $(uname -m)"; exit 1 ;;
+    esac
+
+    curl -LO https://download.oracle.com/graalvm/${JDK_VERSION}/latest/graalvm-jdk-${JDK_VERSION}_${ARCH}_bin.tar.gz
+    mkdir -p /opt/graalvm-jdk-${JDK_VERSION}
+    tar -xzf graalvm-jdk-${JDK_VERSION}_${ARCH}_bin.tar.gz -C /opt/graalvm-jdk-${JDK_VERSION} --strip-components=1
+    rm graalvm-jdk-${JDK_VERSION}_${ARCH}_bin.tar.gz
+
+    echo "Hint: please add the following lines to your ~/.bashrc or ~/.zshrc to use GraalVM JDK ${JDK_VERSION}:"
+    echo 'export PATH="/opt/graalvm-jdk-'${JDK_VERSION}'/bin:${PATH}"'
+    echo 'export JAVA_HOME="/opt/graalvm-jdk-'${JDK_VERSION}'"'
+
+    export PATH="/opt/graalvm-jdk-${JDK_VERSION}/bin:${PATH}"
+    export JAVA_HOME="/opt/graalvm-jdk-${JDK_VERSION}"
+fi
+# if WITH_GRALLVMJDK is false, fall-back to openjdk,
+# or WITH_OPENJDK is explicitly set to true, install openjdk as well
+if [ "${WITH_GRALLVMJDK}" != true ] || [ "${WITH_OPENJDK}" = true ]; then
+    echo "Installing OpenJDK ${JDK_VERSION}..."
+    apt install -y openjdk-${JDK_VERSION}-jre
+fi
 
 sh -c "curl -L https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.0.4/mill-dist-1.0.4-mill.sh > /usr/local/bin/mill && chmod +x /usr/local/bin/mill"
 


### PR DESCRIPTION
also:
- add `set -euo pipefail` to prevent unexpected failures, and add explicit `|| true` to optional requirements
- print toolchain version in `env-test.sh`
- add concurrency group to prevent multiple docker builds in parallel (which may lead to unexpected :latest tagging)
- increase verilator build parallelism to `-j$(nproc)`