### PR TITLE
fix(docker): default LOCALE to utf-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,7 @@ RUN apt-get update && apt-get install sudo -y \
 ENV PATH="/opt/graalvm-jdk-21/bin:${PATH}"
 ENV JAVA_HOME="/opt/graalvm-jdk-21"
 
+ENV LC_ALL="C.UTF-8"
+ENV LANG="C.UTF-8"
+
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
Default LOCALE in a standard ubuntu installation is en_US.UTF-8, but in ubuntu container it is POSIX or C.

This sets default ENV LC_ALL and LANG to C.UTF-8 to align with standard ubuntu installation.

Downstream Dockerfile: https://github.com/OpenXiangShan/XiangShan/blob/859389870811614a2c3d8708c8bd3bfea558d476/Dockerfile#L16-L23