### PR TITLE
fix(setup.sh): explicit relative path

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -7,7 +7,7 @@ git submodule update --init --recursive DRAMsim3 NEMU NutShell nexus-am
 git submodule update --init XiangShan && make -C XiangShan init;
 
 # Setup XiangShan environment variables
-source env.sh
+source ./env.sh
 # OPTIONAL: export them to .bashrc
 
 echo XS_PROJECT_ROOT: ${XS_PROJECT_ROOT}


### PR DESCRIPTION
In some environment (e.g. GitHub Actions), the default shell is `sh` instead of `bash`, and we did `ln -s bash sh`:
https://github.com/OpenXiangShan/xs-env/blob/366b38e6258ba67b475bf1db74f15fbd168229db/Dockerfile#L6

When `bash` finds `$0` is `sh`, it will enter POSIX-compatible mode. In which mode `source env.sh` will complain `bash: line 10: source: env.sh: file not found`.

Reprod: `bash --posix -c "source env.sh"` and `bash -c "source env.sh"` to see the difference