### PR TITLE
feat: rewrite install scripts & Dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Build docker image
+name: Build & test docker image
 
 on:
   push:
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   build-ubuntu:
+    name: Build Ubuntu ${{ matrix.version }}${{ matrix.suffix }} Image
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,8 +20,14 @@ jobs:
 
     strategy:
       matrix:
-        version: [20.04, 22.04, 24.04]
-        full: [true, false]
+        version:
+          - 20.04
+          - 22.04
+          - 24.04
+        suffix:
+          - ''
+          - '-slim'
+      fail-fast: false
 
     steps:
       - uses: actions/checkout@v7
@@ -36,9 +43,9 @@ jobs:
           images: |
             ghcr.io/${{ github.repository_owner }}/xs-env
           tags: |
-            ${{ matrix.version == '24.04' && 'latest' || '' }}${{ matrix.version == '24.04' && matrix.full && '-full' || '' }}
-            ubuntu-${{ matrix.version }}${{ matrix.full && '-full' || '' }}
-            ubuntu-${{ matrix.version }}-${{ env.DATE }}${{ matrix.full && '-full' || '' }}
+            type=raw,value=latest${{ matrix.suffix }},enable=${{ matrix.version == '24.04' }}
+            ubuntu-${{ matrix.version }}${{ matrix.suffix }}
+            ubuntu-${{ matrix.version }}-${{ env.DATE }}${{ matrix.suffix }}
           labels: |
             maintainer=${{ github.repository_owner }}
 
@@ -55,13 +62,25 @@ jobs:
           context: .
           platforms: linux/amd64
           push: ${{ github.event_name == 'push' }}
+          load: ${{ github.event_name == 'pull_request' }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
+          cache-from: type=gha,scope=ubuntu${{ matrix.version }}${{ matrix.suffix }}
+          cache-to: type=gha,mode=max,scope=ubuntu${{ matrix.version }}${{ matrix.suffix }},ignore-error=true
           build-args: |
             BASE_IMAGE=ubuntu:${{ matrix.version }}
-            WITH_OPTIONAL_TOOLS=${{ matrix.full }}
+            SLIM=${{ matrix.suffix == '-slim' }}
+
+      - name: Run env test
+        run: |
+          source ./setup.sh
+          docker run \
+            -v $GITHUB_WORKSPACE:/workspace \
+            "${{ fromJSON(steps.metadata.outputs.json).tags[0] }}" \
+              bash -c "cd /workspace && git config --global --add safe.directory '*' && source ./env-test.sh"
 
   build-centos7:
+    name: Build CentOS 7 Image
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -102,3 +121,5 @@ jobs:
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
           file: ./centos.Dockerfile
+          cache-from: type=gha,scope=centos7
+          cache-to: type=gha,mode=max,scope=centos7,ignore-error=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,39 @@
 ARG BASE_IMAGE=ubuntu:24.04
 FROM ${BASE_IMAGE}
 
-ARG WITH_OPTIONAL_TOOLS=false
+ARG SLIM=false
 
 RUN cd /bin && ln -sf bash sh
 
-COPY install-verilator.sh /tmp/install-verilator.sh
+WORKDIR /tmp
 COPY setup-tools.sh /tmp/setup-tools.sh
 
-WORKDIR /tmp
-RUN apt-get update && apt-get install sudo -y \
-    && WITH_OPTIONAL_TOOLS=${WITH_OPTIONAL_TOOLS} bash /tmp/setup-tools.sh \
-    && cp /tmp/verilator/ci/docker/run/verilator-wrap.sh /usr/local/bin/ \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && rm -rf /tmp/verilator
+# do not use bash /tmp/setup-tools.sh --target all,
+# to split the whole installation into multiple layers,
+# so that the cache can be reused for each layer
 
+COPY install-scripts/base.sh /tmp/install-scripts/base.sh
+RUN bash /tmp/setup-tools.sh --target base
+
+COPY install-scripts/llvm.sh /tmp/install-scripts/llvm.sh
+RUN bash /tmp/setup-tools.sh --target llvm
+ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
+
+COPY install-scripts/jdk.sh /tmp/install-scripts/jdk.sh
+RUN bash /tmp/setup-tools.sh --target jdk
 ENV PATH="/opt/graalvm-jdk-21/bin:${PATH}"
 ENV JAVA_HOME="/opt/graalvm-jdk-21"
+
+COPY install-scripts/mill.sh /tmp/install-scripts/mill.sh
+RUN bash /tmp/setup-tools.sh --target mill
+
+COPY install-scripts/verilator.sh /tmp/install-scripts/verilator.sh
+RUN bash /tmp/setup-tools.sh --target verilator \
+    && cp /tmp/verilator/ci/docker/run/verilator-wrap.sh /usr/local/bin/ \
+    && rm -rf /tmp/verilator
+
+COPY install-scripts/optional.sh /tmp/install-scripts/optional.sh
+RUN if [ "$SLIM" != true ]; then bash /tmp/setup-tools.sh --target optional; fi
 
 ENV LC_ALL="C.UTF-8"
 ENV LANG="C.UTF-8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM ${BASE_IMAGE}
 ARG SLIM=false
 
 RUN cd /bin && ln -sf bash sh
+RUN echo 'Acquire::Retries "3";' > /etc/apt/apt.conf.d/80-retries
 
 WORKDIR /tmp
 COPY setup-tools.sh /tmp/setup-tools.sh
@@ -13,27 +14,39 @@ COPY setup-tools.sh /tmp/setup-tools.sh
 # so that the cache can be reused for each layer
 
 COPY install-scripts/base.sh /tmp/install-scripts/base.sh
-RUN bash /tmp/setup-tools.sh --target base
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    bash /tmp/setup-tools.sh --target base
 
 COPY install-scripts/llvm.sh /tmp/install-scripts/llvm.sh
-RUN bash /tmp/setup-tools.sh --target llvm
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    bash /tmp/setup-tools.sh --target llvm
 ENV PATH="/usr/lib/llvm-19/bin:${PATH}"
 
 COPY install-scripts/jdk.sh /tmp/install-scripts/jdk.sh
-RUN bash /tmp/setup-tools.sh --target jdk
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    bash /tmp/setup-tools.sh --target jdk
 ENV PATH="/opt/graalvm-jdk-21/bin:${PATH}"
 ENV JAVA_HOME="/opt/graalvm-jdk-21"
 
 COPY install-scripts/mill.sh /tmp/install-scripts/mill.sh
-RUN bash /tmp/setup-tools.sh --target mill
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    bash /tmp/setup-tools.sh --target mill
 
 COPY install-scripts/verilator.sh /tmp/install-scripts/verilator.sh
-RUN bash /tmp/setup-tools.sh --target verilator \
-    && cp /tmp/verilator/ci/docker/run/verilator-wrap.sh /usr/local/bin/ \
-    && rm -rf /tmp/verilator
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    bash /tmp/setup-tools.sh --target verilator && \
+    cp /tmp/verilator/ci/docker/run/verilator-wrap.sh /usr/local/bin/ && \
+    rm -rf /tmp/verilator
 
 COPY install-scripts/optional.sh /tmp/install-scripts/optional.sh
-RUN if [ "$SLIM" != true ]; then bash /tmp/setup-tools.sh --target optional; fi
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    if [ "$SLIM" != true ]; then bash /tmp/setup-tools.sh --target optional; fi
 
 ENV LC_ALL="C.UTF-8"
 ENV LANG="C.UTF-8"

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     cp /tmp/verilator/ci/docker/run/verilator-wrap.sh /usr/local/bin/ && \
     rm -rf /tmp/verilator
 
+COPY install-scripts/gsim.sh /tmp/install-scripts/gsim.sh
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    bash /tmp/setup-tools.sh --target gsim
+
 COPY install-scripts/optional.sh /tmp/install-scripts/optional.sh
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/README.md
+++ b/README.md
@@ -16,21 +16,22 @@ sudo -s ./setup-tools.sh # use apt to install dependencies, you may modify it to
 source setup.sh # prepare tools, test develop env using a small project
 ```
 
-该脚本会默认使用 GraalVM JDK 21，请在运行上述脚本后将环境变量配置到 profile（例如 `~/.bashrc`）中：
+该脚本会默认从 apt.llvm.org 安装 LLVM 19 工具链到 `/usr/lib/llvm-19`，并将 GraalVM JDK 21 安装到 `/opt/graalvm-jdk-21`。LLVM 命令默认带 `-19` 后缀（例如 `clang-19`）。如需使用不带版本后缀的命令，请在 profile（例如 `~/.bashrc`）中加入以下配置：
 
-This script will use GraalVM JDK 21 by default. Please add the following lines to your profile (e.g., `~/.bashrc`) after running the above script:
+This script will install the LLVM 19 toolchain from apt.llvm.org under `/usr/lib/llvm-19` and GraalVM JDK 21 under `/opt/graalvm-jdk-21`. LLVM commands use a `-19` suffix by default (for example, `clang-19`). To use commands without the version suffix, add the following lines to your profile (e.g. `~/.bashrc`) after running the script:
 
 ```sh
+echo 'export PATH="/usr/lib/llvm-19/bin:${PATH}"' >> ~/.bashrc
 echo 'export PATH="/opt/graalvm-jdk-21/bin:${PATH}"' >> ~/.bashrc
 echo 'export JAVA_HOME="/opt/graalvm-jdk-21"' >> ~/.bashrc
 ```
 
-如需使用 OpenJDK 21，可以在运行 setup-tools.sh 前设置环境变量 `WITH_GRALLVMJDK=false` 来禁用 GraalVM JDK 的安装：
+使用 `--help` 参数查看脚本的更多选项：
 
-If you want to use OpenJDK 21, you can disable GraalVM JDK installation by setting the environment variable `WITH_GRALLVMJDK=false` before running setup-tools.sh:
+Use `--help` to see more options of the script:
 
 ```sh
-sudo -s WITH_GRALLVMJDK=false ./setup-tools.sh
+./setup-tools.sh --help
 ```
 
 由于香山 `master` 分支更新频繁，此仓库中的 submodule 默认追踪香山主线分支上的一个稳定提交，**并不是香山及其他工具的最新版本**。要更新各子仓库到最新版本，可以运行:

--- a/env-test.sh
+++ b/env-test.sh
@@ -3,14 +3,12 @@
 set -euo pipefail
 
 # Setup XiangShan environment variables
-source env.sh
+source ./env.sh
 # OPTIONAL: export them to .bashrc
 
 # NutShell uses similiar develop environment, we use it to test
 # if develop environment has been setup correctly
 export NOOP_HOME=$(pwd)/NutShell
-
-cd ${NEMU_HOME}
 
 # Print version info for verification
 echo "$(which gcc): $(gcc --version | head -n 1)"
@@ -18,21 +16,9 @@ echo "$(which clang): $(clang --version | head -n 1)"
 echo "$(which java): $(java --version | head -n 1)"
 echo "$(which verilator): $(verilator --version | head -n 1)"
 
-# CPT_restorer need -march=rv64gcbvh_zk support. Test here.
-CPT_CROSS_COMPILE_LIST='riscv64-linux-gnu- riscv64-unknown-linux-gnu-'
-CPT_CROSS_COMPILE=
-for COMPILE in $CPT_CROSS_COMPILE_LIST; do
-  if command -v "${COMPILE}gcc" >/dev/null 2>&1 &&
-    echo | "${COMPILE}gcc" -S -march=rv64gcbvh_zk -o /dev/null -x c -; then
-    CPT_CROSS_COMPILE=$COMPILE
-    break
-  fi
-done
-if [ -z "${CPT_CROSS_COMPILE:-}" ]; then
-  echo 'No supported RISC-V compiler found! riscv64[-unknown]-linux-gnu-gcc with -march=rv64gcbvh_zk support needed.'
-  exit 1
-fi
-make riscv64-nutshell-ref_defconfig CPT_CROSS_COMPILE=${CPT_CROSS_COMPILE}
+# test NEMU compile
+cd ${NEMU_HOME}
+make riscv64-nutshell-ref_defconfig
 make
 
 # Compile processor project

--- a/env-test.sh
+++ b/env-test.sh
@@ -15,6 +15,7 @@ echo "$(which gcc): $(gcc --version | head -n 1)"
 echo "$(which clang): $(clang --version | head -n 1)"
 echo "$(which java): $(java --version | head -n 1)"
 echo "$(which verilator): $(verilator --version | head -n 1)"
+echo "$(which gsim): $(gsim --version | head -n 1)"
 
 # test NEMU compile
 cd ${NEMU_HOME}

--- a/install-scripts/base.sh
+++ b/install-scripts/base.sh
@@ -1,0 +1,37 @@
+# Install base dependencies
+
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y \
+    sudo \
+    vim \
+    git \
+    make \
+    g++ \
+    time \
+    curl \
+    ca-certificates \
+    xz-utils \
+    libreadline6-dev \
+    libsdl2-dev \
+    libgmp-dev \
+    g++-riscv64-linux-gnu \
+    zlib1g-dev \
+    device-tree-compiler \
+    flex \
+    autoconf \
+    bison \
+    sqlite3 \
+    libsqlite3-dev \
+    zstd \
+    libzstd-dev \
+    python-is-python3 \
+    python3-protobuf \
+    python3-grpc-tools \
+    python3-psutil \
+    numactl
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/install-scripts/base.sh
+++ b/install-scripts/base.sh
@@ -33,5 +33,3 @@ apt-get install -y \
     python3-grpc-tools \
     python3-psutil \
     numactl
-apt-get clean
-rm -rf /var/lib/apt/lists/*

--- a/install-scripts/gsim.sh
+++ b/install-scripts/gsim.sh
@@ -1,0 +1,35 @@
+# Install gsim
+
+set -euo pipefail
+
+LLVM_VERSION=19 # not a must, but better keep consistent with llvm.sh
+
+echo "Installing deps for gsim..."
+apt-get update
+apt-get install -y \
+    libgmp-dev
+
+GSIM_LATEST_VERSION=$(curl -s --retry 3 https://api.github.com/repos/OpenXiangShan/gsim/releases/latest | grep "tag_name" | cut -d '"' -f 4)
+
+if [ -z "${GSIM_LATEST_VERSION}" ]; then
+    echo "Failed to get the latest gsim version from GitHub API"
+    exit 1
+fi
+
+ARCH="$(uname -m)"
+case "${ARCH}" in
+    x86_64) GSIM_ARCH="X64" ;;
+    aarch64) GSIM_ARCH="ARM64" ;;
+    *) echo "Unsupported architecture for gsim: ${ARCH}"; exit 1 ;;
+esac
+
+GSIM_FILE=$(curl -s --retry 3 https://api.github.com/repos/OpenXiangShan/gsim/releases/latest | grep "name" | grep "gsim-clang${LLVM_VERSION}\.[0-9]\+\.[0-9]\+-${GSIM_ARCH}" | cut -d '"' -f 4)
+
+if [ -z "${GSIM_FILE}" ]; then
+    echo "Failed to get the gsim file name for ${GSIM_ARCH} from GitHub API"
+    exit 1
+fi
+
+echo "Installing gsim ${GSIM_LATEST_VERSION} for ${GSIM_ARCH}..."
+curl -fL --retry 3 "https://github.com/OpenXiangShan/gsim/releases/download/${GSIM_LATEST_VERSION}/${GSIM_FILE}" -o /usr/local/bin/gsim
+chmod +x /usr/local/bin/gsim

--- a/install-scripts/jdk.sh
+++ b/install-scripts/jdk.sh
@@ -1,0 +1,28 @@
+# Install GraalVM JDK
+
+set -euo pipefail
+
+JDK_VERSION=21 # do not change this unless tested, XiangShan does not compile with JDK 25 yet
+
+# GraalVM has better performance than openjdk,
+# so install it instead of apt openjdk.
+echo "Installing GraalVM JDK ${JDK_VERSION}..."
+
+case "$(uname -m)" in
+    x86_64) ARCH="linux-x64" ;;
+    aarch64) ARCH="linux-aarch64" ;;
+    *) echo "Unsupported architecture for GraalVM JDK: $(uname -m)"; exit 1 ;;
+esac
+
+curl -fLO --retry 3 "https://download.oracle.com/graalvm/${JDK_VERSION}/latest/graalvm-jdk-${JDK_VERSION}_${ARCH}_bin.tar.gz"
+mkdir -p "/opt/graalvm-jdk-${JDK_VERSION}"
+tar -xzf "graalvm-jdk-${JDK_VERSION}_${ARCH}_bin.tar.gz" \
+    -C "/opt/graalvm-jdk-${JDK_VERSION}" --strip-components=1
+rm "graalvm-jdk-${JDK_VERSION}_${ARCH}_bin.tar.gz"
+
+echo "Hint: please add the following lines to your ~/.bashrc or ~/.zshrc to use GraalVM JDK ${JDK_VERSION}:"
+echo 'export PATH="/opt/graalvm-jdk-'${JDK_VERSION}'/bin:${PATH}"'
+echo 'export JAVA_HOME="/opt/graalvm-jdk-'${JDK_VERSION}'"'
+
+export PATH="/opt/graalvm-jdk-${JDK_VERSION}/bin:${PATH}"
+export JAVA_HOME="/opt/graalvm-jdk-${JDK_VERSION}"

--- a/install-scripts/llvm.sh
+++ b/install-scripts/llvm.sh
@@ -1,0 +1,41 @@
+# Install LLVM toolchain from apt.llvm.org
+
+set -euo pipefail
+
+LLVM_VERSION=19 # do not change this unless tested
+
+# GSIM requires clang 19+, and difftest PGO uses LLVM BOLT.
+# The clang/bolt packages in Ubuntu apt repos might be too old (i.e. Ubuntu 24.04 ships with clang 18),
+# so we install a fixed LLVM version from apt.llvm.org instead.
+echo "Installing LLVM ${LLVM_VERSION} toolchain..."
+
+LLVM_CODENAME="$(sed -n -e 's/^VERSION_CODENAME=//p' -e 's/^UBUNTU_CODENAME=//p' /etc/os-release \
+    | head -n 1 | tr -d '"')"
+if [ -z "${LLVM_CODENAME}" ]; then
+    echo "Unable to determine Ubuntu codename" >&2
+    exit 1
+fi
+
+install -d -m 0755 /etc/apt/keyrings
+curl -fL --retry 3 https://apt.llvm.org/llvm-snapshot.gpg.key \
+    -o /etc/apt/keyrings/llvm.asc
+printf 'deb [signed-by=/etc/apt/keyrings/llvm.asc] https://apt.llvm.org/%s/ llvm-toolchain-%s-19 main\n' \
+    "${LLVM_CODENAME}" "${LLVM_CODENAME}" \
+    > /etc/apt/sources.list.d/llvm-19.list
+
+apt-get update
+# clang: for clang, clang++, etc.
+# bolt: for pgo
+# llvm: for llvm-profdata (also for pgo)
+apt-get install -y --no-install-recommends \
+    clang-${LLVM_VERSION} \
+    bolt-${LLVM_VERSION} \
+    llvm-${LLVM_VERSION}
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+
+echo "Hint: By default, LLVM tools are available with the -${LLVM_VERSION} suffix, such as clang-${LLVM_VERSION} and llvm-profdata-${LLVM_VERSION}."
+echo "Hint: To use LLVM tools without the -${LLVM_VERSION} suffix, add the following line to your ~/.bashrc or ~/.zshrc:"
+echo 'export PATH="/usr/lib/llvm-'${LLVM_VERSION}'/bin:${PATH}"'
+
+export PATH="/usr/lib/llvm-${LLVM_VERSION}/bin:${PATH}"

--- a/install-scripts/llvm.sh
+++ b/install-scripts/llvm.sh
@@ -30,8 +30,6 @@ apt-get install -y --no-install-recommends \
     clang-${LLVM_VERSION} \
     bolt-${LLVM_VERSION} \
     llvm-${LLVM_VERSION}
-apt-get clean
-rm -rf /var/lib/apt/lists/*
 
 echo "Hint: By default, LLVM tools are available with the -${LLVM_VERSION} suffix, such as clang-${LLVM_VERSION} and llvm-profdata-${LLVM_VERSION}."
 echo "Hint: To use LLVM tools without the -${LLVM_VERSION} suffix, add the following line to your ~/.bashrc or ~/.zshrc:"

--- a/install-scripts/llvm.sh
+++ b/install-scripts/llvm.sh
@@ -9,18 +9,16 @@ LLVM_VERSION=19 # do not change this unless tested
 # so we install a fixed LLVM version from apt.llvm.org instead.
 echo "Installing LLVM ${LLVM_VERSION} toolchain..."
 
-LLVM_CODENAME="$(sed -n -e 's/^VERSION_CODENAME=//p' -e 's/^UBUNTU_CODENAME=//p' /etc/os-release \
-    | head -n 1 | tr -d '"')"
+LLVM_CODENAME="$(sed -n -e 's/^VERSION_CODENAME=//p' -e 's/^UBUNTU_CODENAME=//p' /etc/os-release | head -n 1 | tr -d '"')"
 if [ -z "${LLVM_CODENAME}" ]; then
     echo "Unable to determine Ubuntu codename" >&2
     exit 1
 fi
+LLVM_SUITE="llvm-toolchain-${LLVM_CODENAME}-${LLVM_VERSION}"
 
 install -d -m 0755 /etc/apt/keyrings
-curl -fL --retry 3 https://apt.llvm.org/llvm-snapshot.gpg.key \
-    -o /etc/apt/keyrings/llvm.asc
-printf 'deb [signed-by=/etc/apt/keyrings/llvm.asc] https://apt.llvm.org/%s/ llvm-toolchain-%s-19 main\n' \
-    "${LLVM_CODENAME}" "${LLVM_CODENAME}" \
+curl -fL --retry 3 https://apt.llvm.org/llvm-snapshot.gpg.key -o /etc/apt/keyrings/llvm.asc
+printf 'deb [signed-by=/etc/apt/keyrings/llvm.asc] https://apt.llvm.org/%s/ %s main\n' "${LLVM_CODENAME}" "${LLVM_SUITE}" \
     > /etc/apt/sources.list.d/llvm-19.list
 
 apt-get update
@@ -28,6 +26,7 @@ apt-get update
 # bolt: for pgo
 # llvm: for llvm-profdata (also for pgo)
 apt-get install -y --no-install-recommends \
+    -t "${LLVM_SUITE}" \
     clang-${LLVM_VERSION} \
     bolt-${LLVM_VERSION} \
     llvm-${LLVM_VERSION}

--- a/install-scripts/mill.sh
+++ b/install-scripts/mill.sh
@@ -1,0 +1,7 @@
+# Install Mill
+
+set -euo pipefail
+
+curl -fL --retry 3 https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.0.4/mill-dist-1.0.4-mill.sh \
+    > /usr/local/bin/mill
+chmod +x /usr/local/bin/mill

--- a/install-scripts/mill.sh
+++ b/install-scripts/mill.sh
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-curl -fL --retry 3 https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.0.4/mill-dist-1.0.4-mill.sh \
-    > /usr/local/bin/mill
+echo "Installing mill..."
+curl -fL --retry 3 https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.0.4/mill-dist-1.0.4-mill.sh -o /usr/local/bin/mill
 chmod +x /usr/local/bin/mill

--- a/install-scripts/optional.sh
+++ b/install-scripts/optional.sh
@@ -1,0 +1,16 @@
+# Install optional tools
+
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update
+apt-get install -y \
+    proxychains4 \
+    htop \
+    zsh \
+    tmux \
+    rsync \
+    wget
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/install-scripts/optional.sh
+++ b/install-scripts/optional.sh
@@ -12,5 +12,3 @@ apt-get install -y \
     tmux \
     rsync \
     wget
-apt-get clean
-rm -rf /var/lib/apt/lists/*

--- a/install-scripts/verilator.sh
+++ b/install-scripts/verilator.sh
@@ -1,23 +1,29 @@
-# https://verilator.org/guide/latest/install.html
+# Install verilator
 
-# NOTE: ccache is intentionally removed from the dependencies list, since:
-#   1. it does not help XiangShan's build performance in most cases, as slight change in chisel result in significant change in cpp code
-#   2. it introduces too much IO overhead
+# https://verilator.org/guide/latest/install.html
 
 set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
+# NOTE: ccache is intentionally removed from the dependencies list, since:
+#   1. it does not help XiangShan's build performance in most cases, as slight change in chisel result in significant change in cpp code
+#   2. it introduces too much IO overhead
+
+apt-get update
 apt-get install -y git help2man perl python3 make autoconf g++ flex bison
 apt-get install -y libgoogle-perftools-dev libjemalloc-dev numactl perl-doc
 apt-get install -y libfl2 || true  # Ubuntu only (ignore if gives error)
 apt-get install -y libfl-dev || true  # Ubuntu only (ignore if gives error)
 apt-get install -y zlibc zlib1g zlib1g-dev || true  # Ubuntu only (ignore if gives error)
+apt-get clean
+rm -rf /var/lib/apt/lists/*
 
-# we recommend using clang-19 for the moment, but it's not default behavior of ubuntu 24.04
-# so check if clang is installed before actually calling apt install to avoid multiple versions conflict
+# setup-tools.sh installs the pinned LLVM release before invoking this script.
+# do not use apt clang, veriator 5.050+ requires clang 18+, which is not available in Ubuntu 20.04/22.04 apt repos.
 if ! command -v clang >/dev/null 2>&1; then
-    apt-get install -y clang
+    echo "clang is required to build Verilator; run setup-tools.sh first to install the pinned LLVM release." >&2
+    exit 1
 fi
 
 git clone https://github.com/verilator/verilator

--- a/install-scripts/verilator.sh
+++ b/install-scripts/verilator.sh
@@ -16,8 +16,6 @@ apt-get install -y libgoogle-perftools-dev libjemalloc-dev numactl perl-doc
 apt-get install -y libfl2 || true  # Ubuntu only (ignore if gives error)
 apt-get install -y libfl-dev || true  # Ubuntu only (ignore if gives error)
 apt-get install -y zlibc zlib1g zlib1g-dev || true  # Ubuntu only (ignore if gives error)
-apt-get clean
-rm -rf /var/lib/apt/lists/*
 
 # setup-tools.sh installs the pinned LLVM release before invoking this script.
 # do not use apt clang, veriator 5.050+ requires clang 18+, which is not available in Ubuntu 20.04/22.04 apt repos.

--- a/setup-tools.sh
+++ b/setup-tools.sh
@@ -47,9 +47,6 @@ run_target() {
         base)
             source "${SCRIPT_DIR}/install-scripts/base.sh"
             ;;
-        optional)
-            source "${SCRIPT_DIR}/install-scripts/optional.sh"
-            ;;
         llvm)
             source "${SCRIPT_DIR}/install-scripts/llvm.sh"
             ;;
@@ -62,6 +59,12 @@ run_target() {
         verilator)
             source "${SCRIPT_DIR}/install-scripts/verilator.sh"
             ;;
+        gsim)
+            source "${SCRIPT_DIR}/install-scripts/gsim.sh"
+            ;;
+        optional)
+            source "${SCRIPT_DIR}/install-scripts/optional.sh"
+            ;;
         all)
             run_target default
             run_target optional
@@ -73,6 +76,7 @@ run_target() {
             run_target jdk
             run_target mill
             run_target verilator
+            run_target gsim
             ;;
         *)
             echo "Unknown target: $1" >&2

--- a/setup-tools.sh
+++ b/setup-tools.sh
@@ -3,97 +3,83 @@
 
 set -euo pipefail
 
+SCRIPT_PATH="${BASH_SOURCE[0]:-$0}"
+SCRIPT_DIR="$(dirname "$(realpath "$SCRIPT_PATH")")"
+
 # make apt non-interactive to avoid tzdata prompt
 export DEBIAN_FRONTEND=noninteractive
 
-apt update
-apt install -y \
-    vim \
-    wget \
-    git \
-    make \
-    g++ \
-    time \
-    curl \
-    libreadline6-dev \
-    libsdl2-dev \
-    libgmp-dev \
-    g++-riscv64-linux-gnu \
-    zlib1g-dev \
-    device-tree-compiler \
-    flex \
-    autoconf \
-    bison \
-    sqlite3 \
-    libsqlite3-dev \
-    zstd \
-    libzstd-dev \
-    python-is-python3 \
-    python3-protobuf \
-    python3-grpc-tools \
-    python3-psutil \
-    numactl
+# Default values, can be overridden by command line options below
+TARGET=default
 
-WITH_OPTIONAL_TOOLS=${WITH_OPTIONAL_TOOLS:-false}
-if [ "$WITH_OPTIONAL_TOOLS" = true ]; then
-    apt install -y \
-        proxychains4 \
-        htop \
-        zsh \
-        tmux \
-        rsync
-fi
+print_usage() {
+    cat <<EOF
+Usage: $0 [OPTIONS]
+  --target TARGET        install only TARGET (all, base, optional, llvm, jdk, mill, verilator)
+  -h, --help             show this help message
+EOF
+}
 
-# GSIM requires clang 19+
-if apt list "clang*" | grep clang-19; then
-    apt install -y clang-19
-    apt install -y bolt-19 || echo "Skipping bolt-19 installation, not available in apt repos"
-    for bin in $(ls /usr/bin/*-19); do
-        base=$(basename $bin)
-        alt=${base%-19}
-        update-alternatives --install /usr/bin/$alt $alt /usr/bin/$base 100
-        update-alternatives --set $alt /usr/bin/$base
-    done
-else
-    echo "Warning: clang-19 is not available, falling back to default clang."
-    echo "This may be because you are not using the Ubuntu version we recommend."
-    apt install -y clang
-    apt install -y llvm-bolt || echo "Skipping llvm-bolt installation, not available in apt repos"
-fi
-
-# grallvm has better performace and is enabled by default
-WITH_GRALLVMJDK=${WITH_GRALLVMJDK:-true}
-WITH_OPENJDK=${WITH_OPENJDK:-false}
-JDK_VERSION=21 # do not change this unless tested, XiangShan does not compile with JDK 25 yet
-if [ "${WITH_GRALLVMJDK}" = true ]; then
-    echo "Installing GraalVM JDK ${JDK_VERSION}..."
-
-    case "$(uname -m)" in
-        x86_64) ARCH="linux-x64" ;;
-        aarch64) ARCH="linux-aarch64" ;;
-        *) echo "Unsupported architecture for GraalVM JDK: $(uname -m)"; exit 1 ;;
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --target)
+            if [ $# -lt 2 ]; then
+                echo "Missing value for --target" >&2
+                print_usage
+                exit 1
+            fi
+            TARGET="$2"
+            shift
+            ;;
+        -h|--help)
+            print_usage;
+            exit 0 ;;
+        *)
+            echo "Unknown option: $1";
+            print_usage;
+            exit 1 ;;
     esac
+    shift
+done
 
-    curl -LO https://download.oracle.com/graalvm/${JDK_VERSION}/latest/graalvm-jdk-${JDK_VERSION}_${ARCH}_bin.tar.gz
-    mkdir -p /opt/graalvm-jdk-${JDK_VERSION}
-    tar -xzf graalvm-jdk-${JDK_VERSION}_${ARCH}_bin.tar.gz -C /opt/graalvm-jdk-${JDK_VERSION} --strip-components=1
-    rm graalvm-jdk-${JDK_VERSION}_${ARCH}_bin.tar.gz
+run_target() {
+    case "$1" in
+        base)
+            source "${SCRIPT_DIR}/install-scripts/base.sh"
+            ;;
+        optional)
+            source "${SCRIPT_DIR}/install-scripts/optional.sh"
+            ;;
+        llvm)
+            source "${SCRIPT_DIR}/install-scripts/llvm.sh"
+            ;;
+        jdk)
+            source "${SCRIPT_DIR}/install-scripts/jdk.sh"
+            ;;
+        mill)
+            source "${SCRIPT_DIR}/install-scripts/mill.sh"
+            ;;
+        verilator)
+            source "${SCRIPT_DIR}/install-scripts/verilator.sh"
+            ;;
+        all)
+            run_target default
+            run_target optional
+            ;;
+        default)
+            # without optional tools
+            run_target base
+            run_target llvm
+            run_target jdk
+            run_target mill
+            run_target verilator
+            ;;
+        *)
+            echo "Unknown target: $1" >&2
+            print_usage
+            exit 1
+            ;;
+    esac
+}
 
-    echo "Hint: please add the following lines to your ~/.bashrc or ~/.zshrc to use GraalVM JDK ${JDK_VERSION}:"
-    echo 'export PATH="/opt/graalvm-jdk-'${JDK_VERSION}'/bin:${PATH}"'
-    echo 'export JAVA_HOME="/opt/graalvm-jdk-'${JDK_VERSION}'"'
-
-    export PATH="/opt/graalvm-jdk-${JDK_VERSION}/bin:${PATH}"
-    export JAVA_HOME="/opt/graalvm-jdk-${JDK_VERSION}"
-fi
-# if WITH_GRALLVMJDK is false, fall-back to openjdk,
-# or WITH_OPENJDK is explicitly set to true, install openjdk as well
-if [ "${WITH_GRALLVMJDK}" != true ] || [ "${WITH_OPENJDK}" = true ]; then
-    echo "Installing OpenJDK ${JDK_VERSION}..."
-    apt install -y openjdk-${JDK_VERSION}-jre
-fi
-
-sh -c "curl -L https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.0.4/mill-dist-1.0.4-mill.sh > /usr/local/bin/mill && chmod +x /usr/local/bin/mill"
-
-# We need to use Verilator 4.204+, so we install Verilator manually
-source ./install-verilator.sh
+run_target "$TARGET"


### PR DESCRIPTION
Important changes:
1. llvm: **use apt.llvm.org instead of ubuntu source**, providing unified clang version across different base image versions
2. gsim: **add gsim to docker image**

Other:
1. setup-tools: split into install-xxx.sh files and move into install-scripts/xxx.sh
2. setup-tools: add command-line argparse
3. jdk: remove openjdk support, users should be able to run apt install themselves
4. ci: rename docker tags, original '-full' now becomes default (for user), original default now becomes '-slim' (for our CI)
5. ci: add docker env-test to CI
6. env-test: explicily using "source ./env.sh" in env-test.sh, like https://github.com/OpenXiangShan/xs-env/pull/104 does
7. env-test: remove outdated CPT_restorer check
8. docker: split into layers, for better reusability of base layers
9. docker: use --mount cache for apt directories, so we don't need to do `apt clean` and `rm -rf /var/cache/apt/list`